### PR TITLE
ToPrimitiveType fix

### DIFF
--- a/MtconnectTranspiler.Sinks.CSharp/Models/Property.cs
+++ b/MtconnectTranspiler.Sinks.CSharp/Models/Property.cs
@@ -30,7 +30,7 @@ namespace MtconnectTranspiler.Sinks.CSharp.Models
 
             AccessModifier = source.Visibility;
 
-            Type = ScribanHelperMethods.ToPrimitiveType(model, source)?.Name;
+            Type = ScribanHelperMethods.ToPrimitiveType(model, source)?.Name ?? "object";
         }
     }
 }

--- a/MtconnectTranspiler.Sinks.CSharp/Models/ScribanHelperMethods.cs
+++ b/MtconnectTranspiler.Sinks.CSharp/Models/ScribanHelperMethods.cs
@@ -63,6 +63,8 @@ namespace MtconnectTranspiler.Sinks.CSharp.Models
         public static Type ToPrimitiveType(Xmi.XmiDocument model, UmlProperty source)
         {
             var umlDataType = model.LookupDataType(source.PropertyType);
+            if (umlDataType == null)
+                return null;
             return ToPrimitiveType(umlDataType);
         }
 

--- a/MtconnectTranspiler.Sinks.CSharp/MtconnectTranspiler.Sinks.CSharp.csproj
+++ b/MtconnectTranspiler.Sinks.CSharp/MtconnectTranspiler.Sinks.CSharp.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>MTConnect Transpiler Sink for C#</Title>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>mtconnect, tbm0115</Authors>
     <Company>MTConnect Institute; TAMS;</Company>
     <Description>An implementation of `ITranspilerSink` from the `MtconnectTranspiler` library. This libary makes it possible to transpile the MTConnect Standard SysML model into C# code.</Description>


### PR DESCRIPTION
Added null handler to `ToPrimitiveType` function and defaulted the type to `object` if not found